### PR TITLE
[bzip3] Delete the threads feature, fix DLLs on Windows, fix missing find_dependency.

### DIFF
--- a/ports/bzip3/add-find-dependency.patch
+++ b/ports/bzip3/add-find-dependency.patch
@@ -1,0 +1,40 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5b6ad2c..82e210d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -76,15 +76,20 @@ if(BUILD_SHARED_LIBS)
+ endif()
+ install(
+   TARGETS bz3
+-  EXPORT ${CMAKE_PROJECT_NAME}-config
++  EXPORT ${CMAKE_PROJECT_NAME}-targets
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ install(
+-  EXPORT ${CMAKE_PROJECT_NAME}-config
+-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
++  EXPORT ${CMAKE_PROJECT_NAME}-targets
++  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}"
+   NAMESPACE ${CMAKE_PROJECT_NAME}::)
+-
++configure_file(
++  "${CMAKE_CURRENT_SOURCE_DIR}/${CMAKE_PROJECT_NAME}-config.cmake.in"
++  "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
++  @ONLY)
++install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
++  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}")
+ if(BZIP3_BUILD_APPS)
+   add_executable(bzip3)
+   target_sources(bzip3 PRIVATE src/main.c)
+diff --git a/bzip3-config.cmake.in b/bzip3-config.cmake.in
+new file mode 100644
+index 0000000..e45f5a6
+--- /dev/null
++++ b/bzip3-config.cmake.in
+@@ -0,0 +1,5 @@
++if(@BZIP3_ENABLE_PTHREAD@)
++  include(CMakeFindDependencyMacro)
++  find_dependency(Threads)
++endif()
++include("${CMAKE_CURRENT_LIST_DIR}/bzip3-targets.cmake")

--- a/ports/bzip3/default-pthread-to-off-on-windows.patch
+++ b/ports/bzip3/default-pthread-to-off-on-windows.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index df72448..e2eeff6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,7 +11,12 @@ set(CMAKE_C_STANDARD 99)
+ 
+ option(BUILD_SHARED_LIBS "Build libbz3 as a shared library" ON)
+ option(BZIP3_BUILD_APPS "Build bzip3 applications" ON)
+-option(BZIP3_ENABLE_PTHREAD "Enable use of pthread library" ON)
++if(WIN32)
++  set(BZIP3_ENABLE_PTHREAD_DEFAULT OFF)
++else()
++  set(BZIP3_ENABLE_PTHREAD_DEFAULT ON)
++endif()
++option(BZIP3_ENABLE_PTHREAD "Enable use of pthread library" "${BZIP3_ENABLE_PTHREAD_DEFAULT}")
+ option(BZIP3_ENABLE_ARCH_NATIVE "Enable CPU-specific optimizations" OFF)
+ option(BZIP3_ENABLE_STATIC_EXE "Enable static builds of the executable" OFF)
+ 

--- a/ports/bzip3/fix-dllexport.patch
+++ b/ports/bzip3/fix-dllexport.patch
@@ -1,0 +1,45 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6491675..340b71f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -34,6 +34,11 @@ set(libdir ${CMAKE_INSTALL_FULL_LIBDIR})
+ set(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+ set(PACKAGE ${CMAKE_PROJECT_NAME})
+ set(PACKAGE_VERSION ${PROJECT_VERSION})
++if(WIN32 AND BUILD_SHARED_LIBS)
++  set(extra_cflags " -DBZIP3_DLL_IMPORT=1")
++else()
++  set(extra_cflags "")
++endif()
+ configure_file(bzip3.pc.in ${CMAKE_CURRENT_BINARY_DIR}/bzip3.pc @ONLY)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bzip3.pc
+         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+@@ -50,6 +55,10 @@ else()
+ endif()
+ target_sources(bz3 PRIVATE src/libbz3.c)
+ target_compile_definitions(bz3 PUBLIC VERSION="${PROJECT_VERSION}")
++if(WIN32 AND BUILD_SHARED_LIBS)
++  target_compile_definitions(bz3 PRIVATE BZIP3_DLL_EXPORT=1)
++  target_compile_definitions(bz3 INTERFACE BZIP3_DLL_IMPORT=1)
++endif()
+ target_include_directories(
+   bz3
+   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+@@ -82,6 +91,7 @@ endif()
+ install(
+   TARGETS bz3
+   EXPORT ${CMAKE_PROJECT_NAME}-targets
++  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+diff --git a/bzip3.pc.in b/bzip3.pc.in
+index 5f8b118..08f8b09 100644
+--- a/bzip3.pc.in
++++ b/bzip3.pc.in
+@@ -9,4 +9,4 @@ Description: A better and stronger spiritual successor to BZip2
+ Version: @PACKAGE_VERSION@
+ License: LGPL-3.0-or-later
+ Libs: -L${libdir} -lbzip3
+-Cflags: -I${includedir}
++Cflags: -I${includedir}@extra_cflags@

--- a/ports/bzip3/portfile.cmake
+++ b/ports/bzip3/portfile.cmake
@@ -1,21 +1,18 @@
-# Static builds are recommended to avoid the pthread dynamic linking issue.
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO kspalaiologos/bzip3
+    REPO iczelia/bzip3
     REF ${VERSION}
     SHA512 4010194b5cadf94356a9be8f9b87b287c8d098b02377ad106038f469a90812abef7ae05b5ca87896b71f0e0ad304b8971b75e45136f0d9fabf83d0cc21cf9202
     HEAD_REF master
     PATCHES
+        add-find-dependency.patch # https://github.com/iczelia/bzip3/pull/163
+        default-pthread-to-off-on-windows.patch # https://github.com/iczelia/bzip3/pull/164
+        fix-dllexport.patch # https://github.com/iczelia/bzip3/pull/165
         disable-man.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS options
     FEATURES
-        threads  BZIP3_ENABLE_PTHREAD
         tools    BZIP3_BUILD_APPS
 )
 
@@ -33,3 +30,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/bzip3/usage
+++ b/ports/bzip3/usage
@@ -1,0 +1,9 @@
+bzip3 provides CMake targets:
+
+  find_package(bzip3 CONFIG REQUIRED)
+  target_link_libraries(main PUBLIC bzip3::bz3)
+
+bzip3 provides pkg-config modules:
+
+  # A better and stronger spiritual successor to BZip2
+  bzip3

--- a/ports/bzip3/vcpkg.json
+++ b/ports/bzip3/vcpkg.json
@@ -6,13 +6,6 @@
   "license": "LGPL-3.0-or-later",
   "dependencies": [
     {
-      "name": "bzip3",
-      "features": [
-        "threads"
-      ],
-      "platform": "!windows"
-    },
-    {
       "name": "vcpkg-cmake",
       "host": true
     },
@@ -22,10 +15,6 @@
     }
   ],
   "features": {
-    "threads": {
-      "description": "Enable use of pthread library",
-      "supports": "!windows"
-    },
     "tools": {
       "description": "Build bzip3 applications",
       "supports": "!windows"

--- a/versions/b-/bzip3.json
+++ b/versions/b-/bzip3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7fa781ca3c259827fe3a331729ca7b9d240502c6",
+      "git-tree": "3357b3babb27fc0386cb0403290e2fe3830626a7",
       "version": "1.5.2",
       "port-version": 0
     }


### PR DESCRIPTION
Rather than continuing to go in circles I thought I'd just make a PR for you.

Here is a test program demonstrating that this works for the cross product of `{static,dynamic}x{pkgconfig,cmake-configs}x{windows,linux}`

[bz3-test.zip](https://github.com/user-attachments/files/21694179/bz3-test.zip)

I also filed PRs upstream for the individual changes:

* https://github.com/iczelia/bzip3/pull/163
* https://github.com/iczelia/bzip3/pull/164
* https://github.com/iczelia/bzip3/pull/165
