### PR TITLE
[bitmagic] correct license metadata

### DIFF
--- a/ports/bitmagic/portfile.cmake
+++ b/ports/bitmagic/portfile.cmake
@@ -9,4 +9,8 @@ vcpkg_from_github(
 
 file(GLOB HEADER_LIST "${SOURCE_PATH}/src/*.h")
 file(INSTALL ${HEADER_LIST} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/LICENSE"
+        "${SOURCE_PATH}/src/sse2neon.h"
+)

--- a/ports/bitmagic/vcpkg.json
+++ b/ports/bitmagic/vcpkg.json
@@ -3,5 +3,5 @@
   "version": "9.2.1",
   "description": "Algorithms and tools for Algebra of Sets for information retrieval, indexing of databases, scientific algorithms, ranking, clustering, unsupervised machine learning and signal processing.",
   "homepage": "http://bitmagic.io",
-  "license": "Apache-2.0"
+  "license": null
 }

--- a/versions/b-/bitmagic.json
+++ b/versions/b-/bitmagic.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "40ed519f611f9146450185a445f37daa52edfec4",
+      "git-tree": "c7c7bcd5041966a6a585eeb827d6cb985b7ae455",
       "version": "9.2.1",
       "port-version": 0
     },


### PR DESCRIPTION
The upstream license includes an additional product/project page notice requirement: https://github.com/tlk00/BitMagic/blob/4199538f683e313f090e60723f92224bdab606d3/LICENSE#L19-L21

Also install the vendored SSE2NEON MIT notice.