### PR TITLE
[enchantum] add CMake integration regression test

### DIFF
--- a/ports/enchantum/vcpkg.json
+++ b/ports/enchantum/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "enchantum",
   "version": "0.4.0",
   "port-version": 1,
-  "description": "Header-only C++20 fast compile time enum reflection library.",
+  "description": "Header-only C++17 fast compile time enum reflection library.",
   "homepage": "https://github.com/ZXShady/enchantum",
   "license": "MIT",
   "dependencies": [

--- a/scripts/test_ports/vcpkg-ci-enchantum/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-enchantum/portfile.cmake
@@ -1,0 +1,4 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_cmake_configure(SOURCE_PATH "${CURRENT_PORT_DIR}/project")
+vcpkg_cmake_build()

--- a/scripts/test_ports/vcpkg-ci-enchantum/project/CMakeLists.txt
+++ b/scripts/test_ports/vcpkg-ci-enchantum/project/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.20)
+project(vcpkg_ci_enchantum LANGUAGES CXX)
+
+find_package(enchantum CONFIG REQUIRED)
+
+add_executable(vcpkg_ci_enchantum main.cpp)
+target_link_libraries(vcpkg_ci_enchantum PRIVATE enchantum::enchantum)

--- a/scripts/test_ports/vcpkg-ci-enchantum/project/main.cpp
+++ b/scripts/test_ports/vcpkg-ci-enchantum/project/main.cpp
@@ -1,0 +1,15 @@
+#include <enchantum/enchantum.hpp>
+
+#include <string_view>
+
+enum class color
+{
+    red,
+    green,
+    blue
+};
+
+int main()
+{
+    return enchantum::to_string(color::green) == std::string_view{"green"} ? 0 : 1;
+}

--- a/scripts/test_ports/vcpkg-ci-enchantum/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-enchantum/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vcpkg-ci-enchantum",
+  "version-string": "ci",
+  "description": "Validates enchantum CMake integration",
+  "dependencies": [
+    "enchantum",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/e-/enchantum.json
+++ b/versions/e-/enchantum.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a4da5cd54484cf6ca2df733ea55c30b3d7e623cd",
+      "git-tree": "af0dbe6760759ad1a3a04b1f6f90657c0cb70ea5",
       "version": "0.4.0",
       "port-version": 1
     },


### PR DESCRIPTION
Correct the advertised language standard and ensure CI compiles a consumer through the installed enchantum CMake package and target.