### PR TITLE
[baresip-libre] Remove custom usage.

### DIFF
--- a/ports/baresip-libre/portfile.cmake
+++ b/ports/baresip-libre/portfile.cmake
@@ -29,5 +29,4 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME libre CONFIG_PATH lib/cmake/libre)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/baresip-libre/usage
+++ b/ports/baresip-libre/usage
@@ -1,5 +1,0 @@
-baresip-libre provides CMake targets:
-
-    find_package(libre CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE libre::libre)
-

--- a/versions/b-/baresip-libre.json
+++ b/versions/b-/baresip-libre.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5e8f9d6d7ef0cf39e00ac02194d8ad148ec5ec89",
+      "git-tree": "a04e114f78476e424f6fc78f00ba8d738a39dfc4",
       "version": "4.10.0",
       "port-version": 0
     },


### PR DESCRIPTION
The generated usage is better because it includes pkgconfig.

```console
baresip-libre provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(libre CONFIG REQUIRED)
  target_link_libraries(main PRIVATE libre::re libre::libre)

baresip-libre provides pkg-config modules:

  # Generic library for real-time communications
  libre
```